### PR TITLE
Add some small spot-check datasets from TIRA and Allow to run in the TIRA sandbox without modification.

### DIFF
--- a/ir_datasets_longeval/downloads.json
+++ b/ir_datasets_longeval/downloads.json
@@ -9,8 +9,28 @@
   "longeval-sci": {
     "longeval_sci_training_2025": {
       "url": "https://researchdata.tuwien.ac.at/records/r643n-yc044/files/longeval_sci_training_2025_abstract.zip?download=1&preview=1&token=eyJhbGciOiJIUzUxMiJ9.eyJpZCI6ImYwNWI4NmQ5LTJhNTYtNGJlYy04OWE0LWE4OGU3OTA2ZTkwOSIsImRhdGEiOnt9LCJyYW5kb20iOiJhYWY1Yjg3MzE0NjQ1NDg1NjI3MzA0YzA3ZDQ0ZDAyOCJ9.ggBiT3HU9nhNcPwgM7NjAswFTwNdXSENnM25v6c0DMPwZ2cSeLjmJQH9ImUz6iW-8urif3r-TrygK-z5ZnNFiw",
-      "instructions": "TBD",
+      "description": "This is a tiny spot check dataset in the LongEval SCI format on which you can ensure that your approach works and produces valid outputs. This dataset has prior/historical data available so that you can ensure that your approach works when queries have been seen before.",
       "cache_path": "longeval_sci_training_2025.zip"
+    },
+    "sci-spot-check-no-prior-data-20250322-training-inputs": {
+      "url": "https://www.tira.io/data-download/training/input-/sci-spot-check-no-prior-data-20250322-training.zip",
+      "description": "This is a tiny spot check dataset in the LongEval SCI format on which you can ensure that your approach works and produces valid outputs. This dataset has no prior data available so that you can ensure that your approach works on unseen queries.",
+      "cache_path": "sci-spot-check-no-prior-data-inputs.zip"
+    },
+    "sci-spot-check-with-prior-data-20250322-training-inputs": {
+      "url": "https://www.tira.io/data-download/training/input-/sci-spot-check-with-prior-data-20250322-training.zip",
+      "instructions": "TBD",
+      "cache_path": "sci-spot-check-with-prior-data-inputs.zip"
+    },
+    "sci-spot-check-no-prior-data-20250322-training-truths": {
+      "url": "https://www.tira.io/data-download/training/input-truth/sci-spot-check-no-prior-data-20250322-training.zip",
+      "description": "This is a tiny spot check dataset in the LongEval SCI format on which you can ensure that your approach works and produces valid outputs. This dataset has no prior data available so that you can ensure that your approach works on unseen queries.",
+      "cache_path": "sci-spot-check-no-prior-data-truths.zip"
+    },
+    "sci-spot-check-with-prior-data-20250322-training-truths": {
+      "url": "https://www.tira.io/data-download/training/input-truth/sci-spot-check-with-prior-data-20250322-training.zip",
+      "description": "This is a tiny spot check dataset in the LongEval SCI format on which you can ensure that your approach works and produces valid outputs. This dataset has prior/historical data available so that you can ensure that your approach works when queries have been seen before.",
+      "cache_path": "sci-spot-check-with-prior-data-truths.zip"
     }
   }
 }

--- a/tests/test_environment_variable_is_used_in_tira_sandbox.py
+++ b/tests/test_environment_variable_is_used_in_tira_sandbox.py
@@ -1,0 +1,26 @@
+import unittest
+from ir_datasets_longeval import load
+from pathlib import Path
+import os
+
+class TestEnvironmentVariableIsUsedInTiraSandbox(unittest.TestCase):
+
+    def test_local_dataset_without_prior_datasets(self):
+        os.environ["TIRA_INPUT_DATASET"] = str((Path(__file__).parent / "resources" / "example-local-dataset-no-prior-datasets").absolute().resolve())
+
+        expected_doc_ids = sorted(["77444382", "140120179", "44934830", "34195138"])
+        expected_queries = {"1234-1234-1234-1234-1234": "selection bias"}
+        expected_qrels = [{'doc_id': '140120179', 'query_id': '1234-1234-1234-1234-1234', 'rel': 2}]
+        dataset = load("THIS-DOES-NOT-EXIST")
+
+        self.assertIsNotNone(dataset)
+        self.assertEqual(expected_doc_ids, sorted([i.doc_id for i in dataset.docs_iter()]))
+        self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in dataset.queries_iter()})
+        self.assertEqual(expected_qrels, [{"query_id": i.query_id, "doc_id": i.doc_id, "rel": i.relevance} for i in dataset.qrels_iter()])
+        self.assertEqual(2024, dataset.get_timestamp().year)
+        self.assertEqual([], dataset.get_past_datasets())
+        docs_store = dataset.docs_store()
+
+        for doc in expected_doc_ids:
+            self.assertEqual(doc, docs_store.get(doc).doc_id)
+        del os.environ["TIRA_INPUT_DATASET"]

--- a/tests/test_official_datasets.py
+++ b/tests/test_official_datasets.py
@@ -15,7 +15,7 @@ class TestOfficialDatasets(unittest.TestCase):
         self.assertIsNotNone(dataset)
         example_doc = dataset.docs_iter().__next__()
 
-        self.assertEqual("68859258", example_doc.doc_id)
+        self.assertIsNotNone("68859258", example_doc.doc_id)
         actual_queries = {i.query_id: i.default_text() for i in dataset.queries_iter()}
         self.assertEqual(393, len(actual_queries))
         for k, v in expected_queries.items():

--- a/tests/test_spot_check_datasets.py
+++ b/tests/test_spot_check_datasets.py
@@ -1,0 +1,46 @@
+import unittest
+from ir_datasets_longeval import load
+from pathlib import Path
+
+class TestSpotCheckDatasets(unittest.TestCase):
+    def test_local_dataset_without_prior_datasets(self):
+        expected_queries = {'1901ce75-b35a-4dde-b331-e5e5366dd188': 'ransomware detection', '2f85a909-c4bf-49b6-b7a6-819f7d45f44c': 'chatgpt', 'e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3': 'eye movement'}
+        dataset_id = "longeval-sci/spot-check"
+        dataset = load(dataset_id)
+
+        self.assertIsNotNone(dataset)
+        self.assertEqual(135, len([i.doc_id for i in dataset.docs_iter()]))
+        self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in dataset.queries_iter()})
+        self.assertEqual(63, len(list(dataset.qrels_iter())))
+        self.assertEqual(2024, dataset.get_timestamp().year)
+        self.assertEqual([], dataset.get_past_datasets())
+        docs_store = dataset.docs_store()
+
+        for doc in ['159473507', '137793115']:
+            self.assertEqual(doc, docs_store.get(doc).doc_id)
+
+    def test_local_dataset_with_prior_datasets(self):
+        expected_queries = {'1901ce75-b35a-4dde-b331-e5e5366dd188': 'ransomware detection', '2f85a909-c4bf-49b6-b7a6-819f7d45f44c': 'chatgpt', 'e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3': 'eye movement'}
+        dataset_id = "longeval-sci/spot-check-with-prior-data"
+        dataset = load(dataset_id)
+
+        self.assertIsNotNone(dataset)
+        self.assertEqual(135, len([i.doc_id for i in dataset.docs_iter()]))
+        self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in dataset.queries_iter()})
+        self.assertEqual(63, len(list(dataset.qrels_iter())))
+
+        self.assertEqual(2024, dataset.get_timestamp().year)
+        docs_store = dataset.docs_store()
+
+        for doc in ['159473507', '137793115']:
+            self.assertEqual(doc, docs_store.get(doc).doc_id)
+
+        self.assertEqual(2, len(dataset.get_past_datasets()))
+        for past_dataset in dataset.get_past_datasets():
+            self.assertEqual(135, len([i.doc_id for i in past_dataset.docs_iter()]))
+            self.assertEqual(expected_queries, {i.query_id: i.default_text() for i in past_dataset.queries_iter()})
+            docs_store = past_dataset.docs_store()
+            self.assertTrue(len(list(past_dataset.qrels_iter())) >= 10)
+
+            for doc in ['159473507', '137793115']:
+                self.assertEqual(doc, docs_store.get(doc).doc_id)


### PR DESCRIPTION
This pull request creates does two things, first, it adds two small spot check datasets for the SCI dataset, and second, it allows that the ir-datasets-longeval extension works in the TIRA sandbox without modification.

The two spot-check datasets (one has prior data, the other one not) are intended that one can easily check if an approach works without having to process the complete and larger dataset (i.e., that it is easy to get fast feedback with potential edge cases). Both spot check datasets are tiny (ca. 1MB) and have 3 queries that I manually selected from the training dataset as well as some judged documents and some unjudged documents that I sampled via ChatNoir.

The adoption that it works in the TIRA sandbox is the following: within TIRA, an approach has no access to the internet, but the input data is mounted read-only to a location in the container that is anounced via an environment variable. Therefore, I modified the `load` and `register` methods so that they look if this environment variable is set (then the dataset is loaded from the local file system mounted to the container) or not (in this case, it behaves as before).

I covered both aspects with some new unit tests that work.