### PR TITLE
Prototype to process all lags of a test dataset at once

### DIFF
--- a/ir_datasets_longeval/longeval_sci.py
+++ b/ir_datasets_longeval/longeval_sci.py
@@ -53,7 +53,10 @@ class LongEvalSciDoc(NamedTuple):
     updatedDate: str
 
     def default_text(self):
-        return self.title + " " + self.abstract
+        ret = self.title
+        if self.abstract:
+            ret += " " + self.abstract
+        return ret
 
 
 class ExtractedPath:

--- a/ir_datasets_longeval/longeval_sci.py
+++ b/ir_datasets_longeval/longeval_sci.py
@@ -73,6 +73,7 @@ class LongEvalSciDataset(Dataset):
         yaml_documentation: str = "longeval_sci.yaml",
         timestamp: Optional[str] = None,
         prior_datasets: Optional[List[str]] = None,
+        lag: Optional[str] = None,
     ):
         documentation = YamlDocumentation(yaml_documentation)
         self.base_path = base_path
@@ -86,6 +87,14 @@ class LongEvalSciDataset(Dataset):
             timestamp = self.read_property_from_metadata("timestamp")
 
         self.timestamp = datetime.strptime(timestamp, "%Y-%m")
+
+
+        if not lag:
+            try:
+                lag = self.read_property_from_metadata("lag")
+            except KeyError:
+                lag = None
+        self.lag = lag
 
         if prior_datasets is None:
             prior_datasets = self.read_property_from_metadata("prior-datasets")
@@ -133,6 +142,12 @@ class LongEvalSciDataset(Dataset):
     def get_timestamp(self):
         return self.timestamp
 
+    def get_lag(self):
+        return self.lag
+    
+    def get_lags(self):
+        return None
+
     def get_past_datasets(self):
         return [LongEvalSciDataset(self.base_path / i) for i in self.prior_datasets]
 
@@ -140,8 +155,16 @@ class LongEvalSciDataset(Dataset):
         return json.load(open(self.base_path / "metadata.json", "r"))[property]
 
 
+class MetaDataset(Dataset):
+    def __init__(self, datasets):
+        super().__init__()
+        self._datasets = datasets
+
+    def get_lags(self):
+        return self._datasets
+
 def register_spot_check_datasets():
-    if f"{NAME}/spot-check" in registry:
+    if f"{NAME}/spot-check/no-prior-data" in registry:
         return
 
     base_path = home_path() / NAME / "spot-check"
@@ -162,8 +185,11 @@ def register_spot_check_datasets():
     if not (with_prior_data_inputs / 'qrels.txt').exists():
         copyfile(with_prior_data_truths / 'qrels.txt', with_prior_data_inputs / 'qrels.txt')
 
-    registry.register(f"{NAME}/spot-check", LongEvalSciDataset(no_prior_data_inputs))
-    registry.register(f"{NAME}/spot-check-with-prior-data", LongEvalSciDataset(with_prior_data_inputs))
+    no_prior = LongEvalSciDataset(no_prior_data_inputs, lag="lag-3")
+    prior_data = LongEvalSciDataset(with_prior_data_inputs, lag="lag-4")
+    registry.register(f"{NAME}/spot-check/no-prior-data", no_prior)
+    registry.register(f"{NAME}/spot-check/with-prior-data", prior_data)
+    registry.register(f"{NAME}/spot-check/*", MetaDataset([no_prior, prior_data]))
 
 def register():
     if f"{NAME}/2024-11/train" in registry:

--- a/ir_datasets_longeval/longeval_web.py
+++ b/ir_datasets_longeval/longeval_web.py
@@ -180,6 +180,7 @@ class LongEvalWebDataset(Dataset):
         yaml_documentation: str = "longeval_web.yaml",
         timestamp: Optional[str] = None,
         prior_datasets: Optional[List[str]] = None,
+        lag: Optional[str] = None
     ):
         documentation = YamlDocumentation(yaml_documentation)
         self.base_path = base_path
@@ -193,6 +194,13 @@ class LongEvalWebDataset(Dataset):
             timestamp = self.read_property_from_metadata("timestamp")
 
         self.timestamp = datetime.strptime(timestamp, "%Y-%m")
+
+        if not lag:
+            try:
+                lag = self.read_property_from_metadata("lag")
+            except KeyError:
+                lag = None
+        self.lag = lag
 
         if prior_datasets is None:
             prior_datasets = self.read_property_from_metadata("prior-datasets")
@@ -221,6 +229,13 @@ class LongEvalWebDataset(Dataset):
 
     def get_timestamp(self):
         return self.timestamp
+
+    def get_lag(self):
+        return self.lag
+
+
+    def get_lags(self):
+        return None
 
     def get_past_datasets(self):
         return [

--- a/tests/resources/example-local-dataset-no-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-no-prior-datasets/metadata.json
@@ -1,1 +1,1 @@
-{"timestamp": "2024-11", "prior-datasets": []}
+{"timestamp": "2024-11", "prior-datasets": [], "lag": "lag-1"}

--- a/tests/resources/example-local-dataset-two-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-two-prior-datasets/metadata.json
@@ -1,1 +1,1 @@
-{"timestamp": "2025-01", "prior-datasets": ["../example-local-dataset-no-prior-datasets/", "../example-local-dataset-no-prior-datasets/"]}
+{"timestamp": "2025-01", "prior-datasets": ["../example-local-dataset-no-prior-datasets/", "../example-local-dataset-no-prior-datasets/"], "lag": "lag-2"}

--- a/tests/resources/example-local-dataset-web-no-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-web-no-prior-datasets/metadata.json
@@ -1,5 +1,6 @@
 {
     "base": "longeval-web",
     "timestamp": "2022-06",
-    "prior-datasets": []
+    "prior-datasets": [],
+    "lag": "lag-3"
 }

--- a/tests/resources/example-local-dataset-web-two-prior-datasets/metadata.json
+++ b/tests/resources/example-local-dataset-web-two-prior-datasets/metadata.json
@@ -1,5 +1,6 @@
 {
     "base": "longeval-web",
     "timestamp": "2022-06",
-    "prior-datasets": ["prior-dataset-01", "prior-dataset-02"]
+    "prior-datasets": ["prior-dataset-01", "prior-dataset-02"],
+    "lag": "lag-4"
 }

--- a/tests/test_local_dataset.py
+++ b/tests/test_local_dataset.py
@@ -44,6 +44,8 @@ class TestLocalDataset(unittest.TestCase):
         )
         self.assertEqual(2024, dataset.get_timestamp().year)
         self.assertEqual([], dataset.get_past_datasets())
+        self.assertEqual("lag-1", dataset.get_lag())
+        self.assertEqual(None, dataset.get_lags())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:
@@ -79,6 +81,8 @@ class TestLocalDataset(unittest.TestCase):
         for doc in expected_doc_ids:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
+        self.assertEqual("lag-2", dataset.get_lag())
+        self.assertEqual(None, dataset.get_lags())
         past_datasets = dataset.get_past_datasets()
         self.assertEqual(2, len(past_datasets))
         for past_dataset in past_datasets:
@@ -121,6 +125,8 @@ class TestLocalDataset(unittest.TestCase):
         )
         self.assertEqual(2022, dataset.get_timestamp().year)
         self.assertEqual([], dataset.get_past_datasets())
+        self.assertEqual("lag-3", dataset.get_lag())
+        self.assertEqual(None, dataset.get_lags())
         docs_store = dataset.docs_store()
 
         for doc in expected_doc_ids:
@@ -156,6 +162,9 @@ class TestLocalDataset(unittest.TestCase):
         for doc in expected_doc_ids:
             self.assertEqual(doc, docs_store.get(doc).doc_id)
 
+
+        self.assertEqual("lag-4", dataset.get_lag())
+        self.assertEqual(None, dataset.get_lags())
         past_datasets = dataset.get_past_datasets()
         self.assertEqual(2, len(past_datasets))
         for past_dataset in past_datasets:

--- a/tests/test_spot_check_datasets.py
+++ b/tests/test_spot_check_datasets.py
@@ -5,7 +5,7 @@ from pathlib import Path
 class TestSpotCheckDatasets(unittest.TestCase):
     def test_local_dataset_without_prior_datasets(self):
         expected_queries = {'1901ce75-b35a-4dde-b331-e5e5366dd188': 'ransomware detection', '2f85a909-c4bf-49b6-b7a6-819f7d45f44c': 'chatgpt', 'e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3': 'eye movement'}
-        dataset_id = "longeval-sci/spot-check"
+        dataset_id = "longeval-sci/spot-check/no-prior-data"
         dataset = load(dataset_id)
 
         self.assertIsNotNone(dataset)
@@ -21,7 +21,7 @@ class TestSpotCheckDatasets(unittest.TestCase):
 
     def test_local_dataset_with_prior_datasets(self):
         expected_queries = {'1901ce75-b35a-4dde-b331-e5e5366dd188': 'ransomware detection', '2f85a909-c4bf-49b6-b7a6-819f7d45f44c': 'chatgpt', 'e6195d15-a4b6-4ce7-9b4f-cf39acdd37e3': 'eye movement'}
-        dataset_id = "longeval-sci/spot-check-with-prior-data"
+        dataset_id = "longeval-sci/spot-check/with-prior-data"
         dataset = load(dataset_id)
 
         self.assertIsNotNone(dataset)
@@ -44,3 +44,18 @@ class TestSpotCheckDatasets(unittest.TestCase):
 
             for doc in ['159473507', '137793115']:
                 self.assertEqual(doc, docs_store.get(doc).doc_id)
+
+    def test_all_spot_check_datasets(self):
+        dataset_id = "longeval-sci/spot-check/*"
+        meta_dataset = load(dataset_id)
+        with self.assertRaises(AttributeError):
+            meta_dataset.queries_iter()
+
+        with self.assertRaises(AttributeError):
+            meta_dataset.docs_iter()
+
+        lags = meta_dataset.get_lags()
+        self.assertEqual(2, len(lags))
+        self.assertEqual("lag-3", lags[0].get_lag())
+        self.assertEqual("lag-4", lags[1].get_lag())
+


### PR DESCRIPTION
Dear all,

as discussed in our private chat, this is an idea on how we could ensure that the same software can run all test datasets of a LongEval task and at the same time also on a single test lag.

I sketched this with the sci spot check dataset. There, we currently have the following structure:

- `longeval-sci/spot-check/no-prior-data`: a single test dataset
- `longeval-sci/spot-check/with-prior-data`: a single test dataset
- `longeval-sci/spot-check/*`: All spot check datasets, i.e., a simulation of all results that are to be submitted to a LongEval task


I implemented a small PyTerrier baseline against this ir-datsats interface, and it would look like this:

```
#!/usr/bin/env python3
import click
from ir_datasets_longeval import load
from pathlib import Path
import pyterrier as pt
import pandas as pd


def get_index(ir_dataset, index_directory):
    # PyTerrier needs an absolute path
    index_directory = index_directory.resolve().absolute()

    if not index_directory.exists() or not (index_directory / "data.properties").exists():
        # build the index
        indexer = pt.IterDictIndexer(str(index_directory), overwrite=True, meta={'docno': 100, 'text': 20480})

        # you can do some custom document processing here
        docs = ({"docno": i.doc_id, "text": i.default_text()} for i in ir_dataset.docs_iter())
        indexer.index(docs)

    return pt.IndexFactory.of(str(index_directory))


def process_dataset(ir_dataset, output_directory):
    if (output_directory / "run.txt.gz").exists():
        return

    if not pt.started():
        pt.init()

    index = get_index(ir_dataset, output_directory / "index")
    bm25 = pt.BatchRetrieve(index, wmodel="BM25")

    # potentially do some query processing
    topics = pd.DataFrame([{'qid': i.query_id, 'query': i.default_text()} for i in ir_dataset.queries_iter()])
    
    # PyTerrier needs to use pre-tokenized queries
    tokeniser = pt.autoclass("org.terrier.indexing.tokenisation.Tokeniser").getTokeniser()

    topics["query"] = topics["query"].apply(lambda i: ' '.join(tokeniser.getTokens(i)))

    run = bm25(topics)
    pt.io.write_results(run, output_directory / "run.txt.gz")


@click.command()
@click.option('--dataset', type=str, help='The dataset id or a local directory.')
@click.option('--output-directory', type=click.Path(), help='The output directory.')
def main(dataset, output_directory):
    ir_dataset = load(dataset)

    if not ir_dataset.get_lags():
        process_dataset(ir_dataset, Path(output_directory))
    else:
        for ds in ir_dataset.get_lags():
            process_dataset(ds, Path(output_directory) / ds.get_lag())

if __name__ == '__main__':
    main()
```

This can then be executed via:

```
./baseline.py --dataset longeval-sci/spot-check/no-prior-data --output-directory output-on-no-prior-data
```

respectively:

```
./baseline.py --dataset longeval-sci/spot-check/* --output-directory output-on-all-spot-checks
```


Best regards,

Maik