### PR TITLE
extend meta dataset to official datasets

### DIFF
--- a/ir_datasets_longeval/__init__.py
+++ b/ir_datasets_longeval/__init__.py
@@ -17,7 +17,6 @@ from ir_datasets_longeval.longeval_web import register as register_longeval_web
 
 def read_property_from_metadata(base_path, property):
     base = json.load(open(Path(base_path) / "metadata.json", "r")).get(property, "")
-    print(base)
     return base
 
 

--- a/ir_datasets_longeval/formats.py
+++ b/ir_datasets_longeval/formats.py
@@ -1,0 +1,10 @@
+from ir_datasets.datasets.base import Dataset
+
+
+class MetaDataset(Dataset):
+    def __init__(self, datasets):
+        super().__init__()
+        self._datasets = datasets
+
+    def get_lags(self):
+        return self._datasets

--- a/ir_datasets_longeval/metadata.json
+++ b/ir_datasets_longeval/metadata.json
@@ -1,4 +1,7 @@
 {
+  "longeval-sci/2024-11/train": {
+    "lag": "lag-0"
+  },
   "longeval-web": {
     "queries": {
       "count": 75427,
@@ -6,6 +9,7 @@
     }
   },
   "longeval-web/2022-06": {
+    "lag": "lag-0",
     "qrels": {
       "count": 85776,
       "fields": {
@@ -34,6 +38,7 @@
     }
   },
   "longeval-web/2022-07": {
+    "lag": "lag-1",
     "qrels": {
       "count": 107916,
       "fields": {
@@ -62,6 +67,7 @@
     }
   },
   "longeval-web/2022-08": {
+    "lag": "lag-2",
     "qrels": {
       "count": 133001,
       "fields": {
@@ -90,6 +96,7 @@
     }
   },
   "longeval-web/2022-09": {
+    "lag": "lag-3",
     "qrels": {
       "count": 135483,
       "fields": {
@@ -118,6 +125,7 @@
     }
   },
   "longeval-web/2022-10": {
+    "lag": "lag-4",
     "qrels": {
       "count": 123967,
       "fields": {
@@ -146,6 +154,7 @@
     }
   },
   "longeval-web/2022-11": {
+    "lag": "lag-5",
     "qrels": {
       "count": 138031,
       "fields": {
@@ -174,6 +183,7 @@
     }
   },
   "longeval-web/2022-12": {
+    "lag": "lag-6",
     "qrels": {
       "count": 139035,
       "fields": {
@@ -202,6 +212,7 @@
     }
   },
   "longeval-web/2023-01": {
+    "lag": "lag-7",
     "qrels": {
       "count": 133244,
       "fields": {
@@ -228,5 +239,8 @@
         }
       }
     }
+  },
+  "longeval-web/2023-02": {
+    "lag": "lag-8"
   }
 }

--- a/tests/test_official_datasets.py
+++ b/tests/test_official_datasets.py
@@ -1,4 +1,3 @@
-import itertools
 import unittest
 
 from ir_datasets_longeval import load
@@ -13,39 +12,96 @@ class TestOfficialDatasets(unittest.TestCase):
             {"doc_id": "140120179", "query_id": "1234-1234-1234-1234-1234", "rel": 2}
         ]
 
+        # Dataset
         self.assertIsNotNone(dataset)
         example_doc = dataset.docs_iter().__next__()
 
-        self.assertIsNotNone(example_doc.doc_id)
-        self.assertEqual("68859258", example_doc.doc_id)
+        # Queries
         actual_queries = {i.query_id: i.default_text() for i in dataset.queries_iter()}
         self.assertEqual(393, len(actual_queries))
         for k, v in expected_queries.items():
             self.assertEqual(v, actual_queries[k])
 
+        # Qrels
         self.assertEqual(4262, len(list(dataset.qrels_iter())))
-        self.assertEqual(2024, dataset.get_timestamp().year)
-        self.assertEqual([], dataset.get_past_datasets())
+
+        # Docs
+        self.assertIsNotNone(example_doc.doc_id)
+        self.assertEqual("127164364", example_doc.doc_id)
+
+        # Docstore
         docs_store = dataset.docs_store()
         self.assertEqual("68859258", docs_store.get("68859258").doc_id)
+
+        # Timestamp
+        self.assertEqual(2024, dataset.get_timestamp().year)
+
+        # Prior datasets
+        self.assertEqual([], dataset.get_past_datasets())
+
+        # Lag
+        self.assertEqual("lag-0", dataset.get_lag())
 
     def test_web_dataset(self):
         dataset = load("longeval-web/2022-06")
 
         expected_queries = {"8": "4 mariages 1 enterrement"}
 
+        # Dataset
         self.assertIsNotNone(dataset)
         example_doc = dataset.docs_iter().__next__()
 
-        self.assertEqual("44971", example_doc.doc_id)
-
+        # Queries
         actual_queries = {i.query_id: i.default_text() for i in dataset.queries_iter()}
         self.assertEqual(75427, len(actual_queries))
         for k, v in expected_queries.items():
             self.assertEqual(v, actual_queries[k])
 
+        # Qrels
         self.assertEqual(85776, len(list(dataset.qrels_iter())))
-        self.assertEqual(2022, dataset.get_timestamp().year)
-        self.assertEqual([], dataset.get_past_datasets())
+        
+        # Docs
+        self.assertEqual("938880", example_doc.doc_id)
+
+        # Docstore
         docs_store = dataset.docs_store()
         self.assertEqual("44971", docs_store.get("44971").doc_id)
+        
+        # Timestamp
+        self.assertEqual(2022, dataset.get_timestamp().year)
+
+        # Prior datasets
+        self.assertEqual([], dataset.get_past_datasets())
+        
+        # Lag
+        self.assertEqual("lag-0", dataset.get_lag())
+
+
+    def test_all_sci_datasets(self):
+        dataset_id = "longeval-sci/*"
+        meta_dataset = load(dataset_id)
+
+        with self.assertRaises(AttributeError):
+            meta_dataset.queries_iter()
+
+        with self.assertRaises(AttributeError):
+            meta_dataset.docs_iter()
+
+        lags = meta_dataset.get_lags()
+        self.assertEqual(1, len(lags))
+        self.assertEqual("lag-0", lags[0].get_lag())
+
+
+    def test_all_web_datasets(self):
+        dataset_id = "longeval-web/*"
+        meta_dataset = load(dataset_id)
+
+        with self.assertRaises(AttributeError):
+            meta_dataset.queries_iter()
+
+        with self.assertRaises(AttributeError):
+            meta_dataset.docs_iter()
+
+        lags = meta_dataset.get_lags()
+        self.assertEqual(9, len(lags))
+        self.assertEqual("lag-0", lags[0].get_lag())


### PR DESCRIPTION
Hey, 

I applied the idea of the meta-dataset to the official datasets. 

The official datasets don't have a `metadata.json` file in the `base_path`. Therefore, I load the data from the package `metadata.json`. The `read_property_from_metadata` function needs to be improved in the future but it works for now. 

Best,

Jüri

